### PR TITLE
Fix user order retrieval and add missing relationship

### DIFF
--- a/app/Http/Controllers/Orders/OrderController.php
+++ b/app/Http/Controllers/Orders/OrderController.php
@@ -66,7 +66,7 @@ class OrderController extends Controller
 
     public function userOrders(Request $request)
     {
-        $orders = $request->user()->order()->with(['shippingAddress', 'orderItems.product'])->latest()->get();
+        $orders = $request->user()->orders()->with(['shippingAddress', 'orderItems.product'])->latest()->get();
         return OrderResource::collection($orders);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 
 
@@ -31,4 +32,9 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'remember_token',
     ];
+
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure userOrders uses the proper relationship
- add orders() relationship to User model

## Testing
- `composer test` *(fails: vendor/autoload.php missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688fb7ec8bf0832e81ce99800130043d