### PR TITLE
Fix typo in registration comment

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -56,7 +56,7 @@ class AuthController extends Controller
         //für Email verfy
         event(new Registered($user));
 
-        //gpbt eine JSON antwort zurück
+        //gibt eine JSON Antwort zurück
         return response()->json(['message' => 'User registered'], 201);
     }
 


### PR DESCRIPTION
## Summary
- correct spelling in AuthController to say "gibt eine JSON Antwort zurück"

## Testing
- `composer test` *(fails: require vendor/autoload.php no such file)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_688fbad52ee0832e8307fc64dc396f11