### PR TITLE
Use null-safe product accessor in OrderItemResource

### DIFF
--- a/app/Http/Resources/OrderItemResource.php
+++ b/app/Http/Resources/OrderItemResource.php
@@ -16,7 +16,7 @@ class OrderItemResource extends JsonResource
     {
         return [
             'product_id' => $this->product_id,
-            'product_name' => $this->product->name,
+            'product_name' => $this->product?->name,
             'quantity'   => $this->quantity, //Produkt zahl
             'price'      => $this->price,
             'total'      => $this->total, // Verkaufte Produkt zahl


### PR DESCRIPTION
## Summary
- safeguard product relation in `OrderItemResource` using PHP's null-safe operator to avoid errors when product is missing

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fbde96a40832e958e9193764e401a