### PR TITLE
Log storage files during image upload

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -15,6 +15,8 @@ use App\Models\Tag;
 use App\Http\Controllers\Controller;
 // Request empfangt Formularen und APIs
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 
 //wir erstellen neue ProductController,der von Laravel bassis-classe erbt(jarangel)
 class ProductController extends Controller
@@ -134,10 +136,22 @@ class ProductController extends Controller
             'star' => 'nullable|numeric|min:0|max:5',
         ]);
 
+        $storageRoot = Storage::disk('koyeb')->path('');
+        Log::info('koyeb storage root path: ' . $storageRoot);
+
+        $existingFiles = Storage::disk('koyeb')->allFiles();
+        Log::info('Files on koyeb disk before upload:', $existingFiles);
+
         // Hier wird geprüft, ob eine Bilddatei mitgeschickt wurde. Falls ja, wird sie im Ordner storage/app/public/products/ gespeichert, und der Pfad wird zurückgegeben. Falls nicht, bleibt der Pfad null.
         $path = $request->hasFile('image')
             ? $request->file('image')->store('products', 'koyeb')
             : null;
+
+        if ($path) {
+            Log::info('Image stored at: ' . Storage::disk('koyeb')->path($path));
+            $filesAfter = Storage::disk('koyeb')->allFiles();
+            Log::info('Files on koyeb disk after upload:', $filesAfter);
+        }
 
         //  Erstellt ein neues Produkt in der Datenbank
         $product = Product::create([


### PR DESCRIPTION
## Summary
- log storage disk path and file listings when creating a product image

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: 403 downloading packages from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0fe1d20832e9fd4e022c17c887e