### PR TITLE
Fix favorites endpoint server error

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,7 +7,9 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use App\Models\Order;
+use App\Models\Product;
 
 
 
@@ -40,6 +42,14 @@ class User extends Authenticatable implements MustVerifyEmail
     public function orders(): HasMany
     {
         return $this->hasMany(Order::class);
+    }
+
+    /**
+     * The products that the user has marked as favorites.
+     */
+    public function favoriteProducts(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class, 'favorites')->withTimestamps();
     }
 }
 

--- a/tests/Feature/FavoriteTest.php
+++ b/tests/Feature/FavoriteTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use App\Models\User;
+use App\Models\Product;
+use App\Models\Category;
+use App\Models\Brand;
+
+class FavoriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_retrieve_favorite_products(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::create(['name' => 'Test Category']);
+        $brand = Brand::create(['name' => 'Test Brand']);
+        $product = Product::create([
+            'name' => 'Sample Product',
+            'description' => 'Desc',
+            'category_id' => $category->id,
+            'brand_id' => $brand->id,
+            'price' => 10,
+            'stock' => 5,
+        ]);
+
+        $user->favoriteProducts()->attach($product->id);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/favorites');
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['id' => $product->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- define favoriteProducts relationship on User model
- add test for retrieving favorite products

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689088e02a70832ea2b90b848b280e8b