### PR TITLE
Auto-approve admin comments

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -18,11 +18,15 @@ class CommentController extends Controller
             'content' => 'required|string|max:1000',
         ]);
 
+        $status = auth()->user()?->role === 'admin'
+            ? Comment::STATUS_APPROVED
+            : Comment::STATUS_PENDING;
+
         $comment = Comment::create([
             'user_id' => auth()->id(),
             'product_id' => $productId,
             'content' => $request->content,
-            'status' => 'pending' // Default status
+            'status' => $status,
         ]);
 
         return response()->json([

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use App\Models\User;
+use App\Models\Product;
+use App\Models\Category;
+use App\Models\Brand;
+use App\Models\Comment;
+
+class CommentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createProduct(): Product
+    {
+        $category = Category::create(['name' => 'Test Category']);
+        $brand = Brand::create(['name' => 'Test Brand']);
+
+        return Product::create([
+            'name' => 'Sample Product',
+            'description' => 'Desc',
+            'category_id' => $category->id,
+            'brand_id' => $brand->id,
+            'price' => 10,
+            'stock' => 5,
+        ]);
+    }
+
+    public function test_admin_comment_is_approved_automatically(): void
+    {
+        $product = $this->createProduct();
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        Sanctum::actingAs($admin);
+
+        $response = $this->postJson("/api/products/{$product->id}/comments", [
+            'content' => 'Admin comment',
+        ]);
+
+        $response->assertStatus(201)
+                 ->assertJsonPath('data.status', Comment::STATUS_APPROVED);
+
+        $this->assertDatabaseHas('comments', [
+            'content' => 'Admin comment',
+            'status' => Comment::STATUS_APPROVED,
+        ]);
+    }
+
+    public function test_regular_user_comment_is_pending(): void
+    {
+        $product = $this->createProduct();
+        $user = User::factory()->create(['role' => 'user']);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson("/api/products/{$product->id}/comments", [
+            'content' => 'User comment',
+        ]);
+
+        $response->assertStatus(201)
+                 ->assertJsonPath('data.status', Comment::STATUS_PENDING);
+
+        $this->assertDatabaseHas('comments', [
+            'content' => 'User comment',
+            'status' => Comment::STATUS_PENDING,
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Automatically approve comments created by admin users
- Add tests verifying admin vs regular user comment status

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689097f8e120832e85889e6c1184054f