### PR TITLE
Fix role-based access control

### DIFF
--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -15,11 +15,9 @@ class AdminMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        // AUTHORIZATION DISABLED - Always allow access
-        // Original code commented out:
-        // if ($request->user()->role !== 'admin') {
-        //     return response()->json(['message' => 'Unauthorized'], 403);
-        // }
+        if (! $request->user() || $request->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
 
         return $next($request);
     }

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -16,11 +16,9 @@ class RoleMiddleware
      */
     public function handle(Request $request, Closure $next, $role): Response
     {
-        // AUTHORIZATION DISABLED - Always allow access
-        // Original code commented out:
-        // if (!Auth::check() || Auth::user()->role !== $role) {
-        //     abort(403, 'Unauthorized');
-        // }
+        if (! Auth::check() || Auth::user()->role !== $role) {
+            abort(403, 'Unauthorized');
+        }
 
         return $next($request);
     }

--- a/tests/Feature/AdminAuthorizationTest.php
+++ b/tests/Feature/AdminAuthorizationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdminAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_non_admin_cannot_access_admin_users_route(): void
+    {
+        $user = User::factory()->create(['role' => 'user']);
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/admin/users');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_access_admin_users_route(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        Sanctum::actingAs($admin);
+
+        $response = $this->getJson('/api/admin/users');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- restore admin-only enforcement in AdminMiddleware
- re-enable generic role middleware check
- add tests covering admin user route authorization

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: curl error 56 while downloading packages: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_6891e2f36760832ebaedfd4f05f8d450