### PR TITLE
feat: add basic CRUD for product metadata

### DIFF
--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Brand;
+use Illuminate\Http\Request;
+
+class BrandController extends Controller
+{
+    /**
+     * Display a listing of brands
+     */
+    public function index()
+    {
+        return response()->json(Brand::all());
+    }
+
+    /**
+     * Display the specified brand
+     */
+    public function show($id)
+    {
+        $brand = Brand::findOrFail($id);
+        return response()->json($brand);
+    }
+
+    /**
+     * Store a newly created brand
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:brands',
+        ]);
+
+        $brand = Brand::create([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Brand created!', 'brand' => $brand], 201);
+    }
+
+    /**
+     * Update the specified brand
+     */
+    public function update(Request $request, $id)
+    {
+        $brand = Brand::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:255|unique:brands,name,' . $brand->id,
+        ]);
+
+        $brand->update([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Brand updated!', 'brand' => $brand]);
+    }
+
+    /**
+     * Remove the specified brand
+     */
+    public function destroy($id)
+    {
+        $brand = Brand::findOrFail($id);
+        $brand->delete();
+
+        return response()->json(['message' => 'Brand deleted!']);
+    }
+}

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of categories
+     */
+    public function index()
+    {
+        return response()->json(Category::all());
+    }
+
+    /**
+     * Display the specified category
+     */
+    public function show($id)
+    {
+        $category = Category::findOrFail($id);
+        return response()->json($category);
+    }
+
+    /**
+     * Store a newly created category
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories',
+        ]);
+
+        $category = Category::create([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Category created!', 'category' => $category], 201);
+    }
+
+    /**
+     * Update the specified category
+     */
+    public function update(Request $request, $id)
+    {
+        $category = Category::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories,name,' . $category->id,
+        ]);
+
+        $category->update([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Category updated!', 'category' => $category]);
+    }
+
+    /**
+     * Remove the specified category
+     */
+    public function destroy($id)
+    {
+        $category = Category::findOrFail($id);
+        $category->delete();
+
+        return response()->json(['message' => 'Category deleted!']);
+    }
+}

--- a/app/Http/Controllers/Admin/ColorController.php
+++ b/app/Http/Controllers/Admin/ColorController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Color;
+use Illuminate\Http\Request;
+
+class ColorController extends Controller
+{
+    /**
+     * Display a listing of colors
+     */
+    public function index()
+    {
+        return response()->json(Color::all());
+    }
+
+    /**
+     * Display the specified color
+     */
+    public function show($id)
+    {
+        $color = Color::findOrFail($id);
+        return response()->json($color);
+    }
+
+    /**
+     * Store a newly created color
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:colors',
+        ]);
+
+        $color = Color::create([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Color created!', 'color' => $color], 201);
+    }
+
+    /**
+     * Update the specified color
+     */
+    public function update(Request $request, $id)
+    {
+        $color = Color::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:255|unique:colors,name,' . $color->id,
+        ]);
+
+        $color->update([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Color updated!', 'color' => $color]);
+    }
+
+    /**
+     * Remove the specified color
+     */
+    public function destroy($id)
+    {
+        $color = Color::findOrFail($id);
+        $color->delete();
+
+        return response()->json(['message' => 'Color deleted!']);
+    }
+}

--- a/app/Http/Controllers/Admin/SizeController.php
+++ b/app/Http/Controllers/Admin/SizeController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Size;
+use Illuminate\Http\Request;
+
+class SizeController extends Controller
+{
+    /**
+     * Display a listing of sizes
+     */
+    public function index()
+    {
+        return response()->json(Size::all());
+    }
+
+    /**
+     * Display the specified size
+     */
+    public function show($id)
+    {
+        $size = Size::findOrFail($id);
+        return response()->json($size);
+    }
+
+    /**
+     * Store a newly created size
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:sizes',
+        ]);
+
+        $size = Size::create([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Size created!', 'size' => $size], 201);
+    }
+
+    /**
+     * Update the specified size
+     */
+    public function update(Request $request, $id)
+    {
+        $size = Size::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:255|unique:sizes,name,' . $size->id,
+        ]);
+
+        $size->update([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Size updated!', 'size' => $size]);
+    }
+
+    /**
+     * Remove the specified size
+     */
+    public function destroy($id)
+    {
+        $size = Size::findOrFail($id);
+        $size->delete();
+
+        return response()->json(['message' => 'Size deleted!']);
+    }
+}

--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of tags
+     */
+    public function index()
+    {
+        return response()->json(Tag::all());
+    }
+
+    /**
+     * Display the specified tag
+     */
+    public function show($id)
+    {
+        $tag = Tag::findOrFail($id);
+        return response()->json($tag);
+    }
+
+    /**
+     * Store a newly created tag
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:tags',
+        ]);
+
+        $tag = Tag::create([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Tag created!', 'tag' => $tag], 201);
+    }
+
+    /**
+     * Update the specified tag
+     */
+    public function update(Request $request, $id)
+    {
+        $tag = Tag::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:255|unique:tags,name,' . $tag->id,
+        ]);
+
+        $tag->update([
+            'name' => $request->name,
+        ]);
+
+        return response()->json(['message' => 'Tag updated!', 'tag' => $tag]);
+    }
+
+    /**
+     * Remove the specified tag
+     */
+    public function destroy($id)
+    {
+        $tag = Tag::findOrFail($id);
+        $tag->delete();
+
+        return response()->json(['message' => 'Tag deleted!']);
+    }
+}

--- a/app/Models/Color.php
+++ b/app/Models/Color.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Color extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/app/Models/Size.php
+++ b/app/Models/Size.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Size extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/migrations/2025_08_03_000000_create_colors_table.php
+++ b/database/migrations/2025_08_03_000000_create_colors_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('colors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('colors');
+    }
+};

--- a/database/migrations/2025_08_03_000001_create_sizes_table.php
+++ b/database/migrations/2025_08_03_000001_create_sizes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sizes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sizes');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,11 @@ use App\Http\Controllers\Orders\OrderController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\BrandController;
+use App\Http\Controllers\Admin\TagController;
+use App\Http\Controllers\Admin\ColorController;
+use App\Http\Controllers\Admin\SizeController;
 
 use App\Http\Controllers\Auth\VerificationController;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -118,4 +123,42 @@ Route::prefix('admin')->middleware(['auth:sanctum', 'admin'])->group(function ()
     Route::post('/users', [UserController::class, 'store']);
     Route::patch('/users/{id}', [UserController::class, 'update']);
     Route::delete('/users/{id}', [UserController::class, 'destroy']);
+});
+
+// Admin category, brand, tag, color, and size routes (protected)
+Route::prefix('admin')->middleware(['auth:sanctum', 'admin'])->group(function () {
+    // Category routes
+    Route::get('/categories', [CategoryController::class, 'index']);
+    Route::get('/categories/{id}', [CategoryController::class, 'show']);
+    Route::post('/categories', [CategoryController::class, 'store']);
+    Route::patch('/categories/{id}', [CategoryController::class, 'update']);
+    Route::delete('/categories/{id}', [CategoryController::class, 'destroy']);
+
+    // Brand routes
+    Route::get('/brands', [BrandController::class, 'index']);
+    Route::get('/brands/{id}', [BrandController::class, 'show']);
+    Route::post('/brands', [BrandController::class, 'store']);
+    Route::patch('/brands/{id}', [BrandController::class, 'update']);
+    Route::delete('/brands/{id}', [BrandController::class, 'destroy']);
+
+    // Tag routes
+    Route::get('/tags', [TagController::class, 'index']);
+    Route::get('/tags/{id}', [TagController::class, 'show']);
+    Route::post('/tags', [TagController::class, 'store']);
+    Route::patch('/tags/{id}', [TagController::class, 'update']);
+    Route::delete('/tags/{id}', [TagController::class, 'destroy']);
+
+    // Color routes
+    Route::get('/colors', [ColorController::class, 'index']);
+    Route::get('/colors/{id}', [ColorController::class, 'show']);
+    Route::post('/colors', [ColorController::class, 'store']);
+    Route::patch('/colors/{id}', [ColorController::class, 'update']);
+    Route::delete('/colors/{id}', [ColorController::class, 'destroy']);
+
+    // Size routes
+    Route::get('/sizes', [SizeController::class, 'index']);
+    Route::get('/sizes/{id}', [SizeController::class, 'show']);
+    Route::post('/sizes', [SizeController::class, 'store']);
+    Route::patch('/sizes/{id}', [SizeController::class, 'update']);
+    Route::delete('/sizes/{id}', [SizeController::class, 'destroy']);
 });


### PR DESCRIPTION
## Summary
- add models and migrations for colors and sizes
- implement CRUD controllers for categories, brands, tags, colors, and sizes
- register admin API routes for new resources

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --no-interaction --no-progress` *(failed: unable to access GitHub resources)*

------
https://chatgpt.com/codex/tasks/task_e_6892086171b4832ea51b1c54075cd052