### PR TITLE
feat: allow admin to update orders

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -85,6 +85,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     // Admin order routes
     Route::group(['middleware' => ['admin']], function () {
         Route::get('/admin/orders', [OrderController::class, 'allOrders']);
+        Route::patch('/admin/orders/{order}', [OrderController::class, 'update']);
         Route::patch('/admin/orders/{order}/status', [OrderController::class, 'updateStatus']);
     });
 });

--- a/tests/Feature/OrderUpdateTest.php
+++ b/tests/Feature/OrderUpdateTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use App\Models\User;
+use App\Models\Order;
+use App\Models\ShippingAddress;
+
+class OrderUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_update_order_information(): void
+    {
+        $user = User::factory()->create();
+        $address = ShippingAddress::create([
+            'user_id' => $user->id,
+            'full_name' => 'Old Name',
+            'address_line1' => 'Old Street 1',
+            'address_line2' => null,
+            'city' => 'Old City',
+            'state' => 'Old State',
+            'postal_code' => '11111',
+            'country' => 'Old Country',
+            'phone' => '0000000',
+        ]);
+
+        $order = Order::create([
+            'user_id' => $user->id,
+            'shipping_address_id' => $address->id,
+            'total' => 100,
+            'status' => 'pending',
+        ]);
+
+        $admin = User::factory()->create(['role' => 'admin']);
+        Sanctum::actingAs($admin);
+
+        $response = $this->patchJson("/api/admin/orders/{$order->id}", [
+            'status' => 'processing',
+            'shipping_address' => [
+                'city' => 'New City',
+            ],
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.status', 'processing')
+            ->assertJsonPath('data.shipping_address.city', 'New City');
+
+        $this->assertDatabaseHas('orders', [
+            'id' => $order->id,
+            'status' => 'processing',
+        ]);
+
+        $this->assertDatabaseHas('shipping_addresses', [
+            'id' => $address->id,
+            'city' => 'New City',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow admins to update order status and shipping address
- add API endpoint for updating orders
- cover order updates with feature test

## Testing
- `php artisan test` *(fails: require(/workspace/MS-Lily_api/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68920a4bdcf4832e88d7e6f675dd47ea