### PR TITLE
feat: add automatic API docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Homestead.json
 .env.production
 .phpactor.json
 auth.json
+
+public/api-docs.json

--- a/app/Console/Commands/GenerateApiDocs.php
+++ b/app/Console/Commands/GenerateApiDocs.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Routing\Route as RouteInstance;
+use ReflectionMethod;
+use Illuminate\Foundation\Http\FormRequest;
+
+class GenerateApiDocs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'docs:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate API documentation from routes, controllers, and request rules';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $routes = collect(Route::getRoutes())
+            ->map(function (RouteInstance $route) {
+                return [
+                    'uri' => '/' . ltrim($route->uri(), '/'),
+                    'methods' => $route->methods(),
+                    'name' => $route->getName(),
+                    'action' => $route->getActionName(),
+                    'rules' => $this->getRules($route),
+                ];
+            });
+
+        $path = public_path('api-docs.json');
+        file_put_contents($path, $routes->values()->toJson(JSON_PRETTY_PRINT));
+
+        $this->info("API documentation generated at {$path}");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Extract validation rules from the route's controller.
+     */
+    protected function getRules(RouteInstance $route): array
+    {
+        $action = $route->getActionName();
+        if (!str_contains($action, '@')) {
+            return [];
+        }
+
+        [$controller, $method] = explode('@', $action);
+
+        if (!class_exists($controller) || !method_exists($controller, $method)) {
+            return [];
+        }
+
+        $reflection = new ReflectionMethod($controller, $method);
+        $rules = [];
+
+        foreach ($reflection->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if ($type && is_subclass_of($type->getName(), FormRequest::class)) {
+                $request = app($type->getName());
+                $rules = array_merge($rules, $request->rules());
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    /**
+     * The Artisan commands provided by your application.
+     *
+     * @var array<int, class-string>
+     */
+    protected $commands = [
+        Commands\GenerateApiDocs::class,
+    ];
+
+    /**
+     * Define the application's command schedule.
+     */
+    protected function schedule(Schedule $schedule): void
+    {
+        //
+    }
+
+    /**
+     * Register the commands for the application.
+     */
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,12 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
+        "post-install-cmd": [
+            "@php artisan docs:generate --ansi"
+        ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
+            "@php artisan docs:generate --ansi"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""

--- a/dockerfile
+++ b/dockerfile
@@ -83,7 +83,8 @@ RUN CACHE_STORE=file SESSION_DRIVER=file php artisan config:clear \
    && CACHE_STORE=file SESSION_DRIVER=file php artisan cache:clear \
    && CACHE_STORE=file SESSION_DRIVER=file php artisan route:clear \
    && CACHE_STORE=file SESSION_DRIVER=file php artisan view:clear \
-   && CACHE_STORE=file SESSION_DRIVER=file php artisan config:cache
+   && CACHE_STORE=file SESSION_DRIVER=file php artisan config:cache \
+   && CACHE_STORE=file SESSION_DRIVER=file php artisan docs:generate
 
 # Expose port 3000 (matches your run command)
 EXPOSE 3000
@@ -114,6 +115,9 @@ RUN echo '#!/bin/sh' > /app/start.sh \
    && echo 'else' >> /app/start.sh \
    && echo '    echo "No migrations found, skipping database setup"' >> /app/start.sh \
    && echo 'fi' >> /app/start.sh \
+   && echo '' >> /app/start.sh \
+   && echo '# Generate API documentation' >> /app/start.sh \
+   && echo 'php artisan docs:generate || echo "API docs generation failed"' >> /app/start.sh \
    && echo '' >> /app/start.sh \
    && echo 'echo "Starting PHP development server on port 3000..."' >> /app/start.sh \
    && echo 'exec php -S 0.0.0.0:3000 -t public' >> /app/start.sh \


### PR DESCRIPTION
## Summary
- create `docs:generate` command to produce API documentation from routes, controllers, and form request rules
- run docs generator automatically on install/update via composer scripts
- ignore generated API docs in version control
- execute docs generator in Docker build and startup script so `public/api-docs.json` is always available

## Testing
- `composer test` *(fails: Failed opening required '/workspace/MS-Lily_api/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68921570d6dc832e8add72056ce11ad6