### PR TITLE
Allow updating all user attributes

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -64,16 +64,28 @@ class UserController extends Controller
       $user = User::findOrFail($id);
 
       $request->validate([
-         'name' => 'required|string|max:255',
-         'email' => 'required|string|email|max:255|unique:users,email,' . $user->id,
-         'role' => 'nullable|string|in:admin,user',
+         'name' => 'sometimes|required|string|max:255',
+         'last_name' => 'sometimes|nullable|string|max:255',
+         'email' => 'sometimes|required|string|email|max:255|unique:users,email,' . $user->id,
+         'mobile_number' => 'sometimes|nullable|string|max:255',
+         'role' => 'sometimes|string|in:admin,user',
+         'country' => 'sometimes|nullable|string|max:255',
+         'address' => 'sometimes|nullable|string|max:255',
+         'city' => 'sometimes|nullable|string|max:255',
+         'postal_code' => 'sometimes|nullable|string|max:255',
       ]);
 
-      $user->update([
-         'name' => $request->name,
-         'email' => $request->email,
-         'role' => $request->role ?? $user->role,
-      ]);
+      $user->update($request->only([
+         'name',
+         'last_name',
+         'email',
+         'mobile_number',
+         'role',
+         'country',
+         'address',
+         'city',
+         'postal_code',
+      ]));
 
       return response()->json(['message' => 'User updated successfully!', 'user' => $user]);
    }


### PR DESCRIPTION
## Summary
- allow admin to update full user profile fields

## Testing
- `php artisan test` *(fails: Failed to open required vendor/autoload.php)*
- `composer install` *(fails: Failed to clone https://github.com/doctrine/inflector.git, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892182a55cc832e9f7690b997273aac