### PR TITLE
Add status counts to admin comments endpoint

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -128,6 +128,13 @@ class CommentController extends Controller
         $perPage = $request->get('per_page', 15);
         $comments = $query->paginate($perPage);
 
+        $counts = [
+            'total' => Comment::count(),
+            'pending' => Comment::where('status', Comment::STATUS_PENDING)->count(),
+            'approved' => Comment::where('status', Comment::STATUS_APPROVED)->count(),
+            'rejected' => Comment::where('status', Comment::STATUS_REJECTED)->count(),
+        ];
+
         return response()->json([
             'data' => CommentResource::collection($comments->items()),
             'meta' => [
@@ -135,7 +142,8 @@ class CommentController extends Controller
                 'per_page' => $comments->perPage(),
                 'total' => $comments->total(),
                 'last_page' => $comments->lastPage(),
-            ]
+            ],
+            'counts' => $counts,
         ]);
     }
 

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -124,5 +124,43 @@ class CommentTest extends TestCase
             'content' => 'Owner comment',
         ]);
     }
+
+    public function test_admin_comments_endpoint_returns_counts(): void
+    {
+        $product = $this->createProduct();
+        $admin = User::factory()->create(['role' => 'admin']);
+        $user = User::factory()->create(['role' => 'user']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'content' => 'Pending comment',
+            'status' => Comment::STATUS_PENDING,
+        ]);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'content' => 'Approved comment',
+            'status' => Comment::STATUS_APPROVED,
+        ]);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'content' => 'Rejected comment',
+            'status' => Comment::STATUS_REJECTED,
+        ]);
+
+        Sanctum::actingAs($admin);
+
+        $response = $this->getJson('/api/admin/comments');
+
+        $response->assertStatus(200)
+                 ->assertJsonPath('counts.total', 3)
+                 ->assertJsonPath('counts.pending', 1)
+                 ->assertJsonPath('counts.approved', 1)
+                 ->assertJsonPath('counts.rejected', 1);
+    }
 }
 


### PR DESCRIPTION
## Summary
- include total/pending/approved/rejected counts in admin comments endpoint
- cover new counts in a feature test

## Testing
- `composer install` *(fails: Proxy CONNECT aborted due to timeout/403)*
- `composer test` *(fails: cannot open vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68923ec553f8832ea7b8cf68ca3cb174