### PR TITLE
Add order summary to admin orders endpoint

### DIFF
--- a/app/Http/Controllers/Orders/OrderController.php
+++ b/app/Http/Controllers/Orders/OrderController.php
@@ -78,7 +78,19 @@ class OrderController extends Controller
     public function allOrders()
     {
         $orders = Order::with(['shippingAddress', 'orderItems.product', 'user'])->latest()->get();
-        return OrderResource::collection($orders);
+
+        $summary = [
+            'total_orders' => Order::count(),
+            'pending' => Order::where('status', 'pending')->count(),
+            'processing' => Order::where('status', 'processing')->count(),
+            'shipped' => Order::where('status', 'shipped')->count(),
+            'delivered' => Order::where('status', 'delivered')->count(),
+            'total_revenue' => Order::sum('total'),
+        ];
+
+        return OrderResource::collection($orders)->additional([
+            'summary' => $summary,
+        ]);
     }
 
     public function updateStatus(Request $request, Order $order)

--- a/tests/Feature/AdminOrdersSummaryTest.php
+++ b/tests/Feature/AdminOrdersSummaryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use App\Models\User;
+use App\Models\Order;
+use App\Models\ShippingAddress;
+
+class AdminOrdersSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_orders_endpoint_returns_summary(): void
+    {
+        $user = User::factory()->create();
+        $address = ShippingAddress::create([
+            'user_id' => $user->id,
+            'full_name' => 'John Doe',
+            'address_line1' => '123 Street',
+            'address_line2' => null,
+            'city' => 'City',
+            'state' => 'State',
+            'postal_code' => '12345',
+            'country' => 'Country',
+            'phone' => '1234567890',
+        ]);
+
+        $orders = [
+            ['status' => 'pending', 'total' => 100],
+            ['status' => 'pending', 'total' => 150],
+            ['status' => 'processing', 'total' => 200],
+            ['status' => 'shipped', 'total' => 250],
+            ['status' => 'delivered', 'total' => 300],
+        ];
+
+        foreach ($orders as $data) {
+            Order::create([
+                'user_id' => $user->id,
+                'shipping_address_id' => $address->id,
+                'total' => $data['total'],
+                'status' => $data['status'],
+            ]);
+        }
+
+        $admin = User::factory()->create(['role' => 'admin']);
+        Sanctum::actingAs($admin);
+
+        $response = $this->getJson('/api/admin/orders');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('summary.total_orders', 5)
+            ->assertJsonPath('summary.pending', 2)
+            ->assertJsonPath('summary.processing', 1)
+            ->assertJsonPath('summary.shipped', 1)
+            ->assertJsonPath('summary.delivered', 1)
+            ->assertJsonPath('summary.total_revenue', 1000);
+    }
+}


### PR DESCRIPTION
## Summary
- include aggregate order counts and revenue in admin orders endpoint
- test summary data for admin orders

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/MS-Lily_api/vendor/autoload.php'...)*


------
https://chatgpt.com/codex/tasks/task_e_6892959b03c8832e9996f5e062a5b868