### PR TITLE
Add canceled orders count to admin summary

### DIFF
--- a/app/Http/Controllers/Orders/OrderController.php
+++ b/app/Http/Controllers/Orders/OrderController.php
@@ -85,6 +85,7 @@ class OrderController extends Controller
             'processing' => Order::where('status', 'processing')->count(),
             'shipped' => Order::where('status', 'shipped')->count(),
             'delivered' => Order::where('status', 'delivered')->count(),
+            'canceled' => Order::where('status', 'canceled')->count(),
             'total_revenue' => Order::sum('total'),
         ];
 

--- a/tests/Feature/AdminOrdersSummaryTest.php
+++ b/tests/Feature/AdminOrdersSummaryTest.php
@@ -34,6 +34,7 @@ class AdminOrdersSummaryTest extends TestCase
             ['status' => 'processing', 'total' => 200],
             ['status' => 'shipped', 'total' => 250],
             ['status' => 'delivered', 'total' => 300],
+            ['status' => 'canceled', 'total' => 50],
         ];
 
         foreach ($orders as $data) {
@@ -51,11 +52,12 @@ class AdminOrdersSummaryTest extends TestCase
         $response = $this->getJson('/api/admin/orders');
 
         $response->assertStatus(200)
-            ->assertJsonPath('summary.total_orders', 5)
+            ->assertJsonPath('summary.total_orders', 6)
             ->assertJsonPath('summary.pending', 2)
             ->assertJsonPath('summary.processing', 1)
             ->assertJsonPath('summary.shipped', 1)
             ->assertJsonPath('summary.delivered', 1)
-            ->assertJsonPath('summary.total_revenue', 1000);
+            ->assertJsonPath('summary.canceled', 1)
+            ->assertJsonPath('summary.total_revenue', 1050);
     }
 }


### PR DESCRIPTION
## Summary
- include canceled order count in order summary
- expand admin orders summary test with a canceled order case

## Testing
- `composer test` *(fails: Failed opening required '/workspace/MS-Lily_api/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68929a26e440832ea52ed958e5fedeb3