### PR TITLE
fix: ensure email verification sent on registration

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -11,7 +11,6 @@ use Illuminate\Validation\Rules\Password;
 use App\Rules\InternationalMobilePhone;
 use App\Models\User;
 use App\Http\Resources\UserResource;
-use Illuminate\Auth\Events\Registered;
 
 class AuthController extends Controller
 {
@@ -53,8 +52,8 @@ class AuthController extends Controller
             'role' => $request->get('role', 'user') //wenn keine Rolle geschrieben wird,wird automatisch user gesetzt
         ]);
 
-        //für Email verfy
-        event(new Registered($user));
+        // Send verification email to the newly registered user
+        $user->sendEmailVerificationNotification();
 
         //gibt eine JSON Antwort zurück
         return response()->json(['message' => 'User registered'], 201);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -15,7 +16,7 @@ use App\Models\Product;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
-    use HasApiTokens, Notifiable;
+    use HasApiTokens, Notifiable, MustVerifyEmailTrait;
 
 
     protected $fillable = [


### PR DESCRIPTION
## Summary
- send verification email after user registration
- enable built-in email verification features on User model

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68931d5d0254832e8102511accf315b4