### PR TITLE
Require all user fields

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -41,15 +41,15 @@ class UserController extends Controller
    {
       $request->validate([
          'name' => 'required|string|max:255',
-         'last_name' => 'nullable|string|max:255',
+         'last_name' => 'required|string|max:255',
          'email' => 'required|string|email|max:255|unique:users',
-         'mobile_number' => 'nullable|string|max:255',
+         'mobile_number' => 'required|string|max:255',
          'password' => 'required|string|min:8|confirmed',
-         'role' => 'nullable|string|in:admin,user',
-         'country' => 'nullable|string|max:255',
-         'address' => 'nullable|string|max:255',
-         'city' => 'nullable|string|max:255',
-         'postal_code' => 'nullable|string|max:255',
+         'role' => 'required|string|in:admin,user',
+         'country' => 'required|string|max:255',
+         'address' => 'required|string|max:255',
+         'city' => 'required|string|max:255',
+         'postal_code' => 'required|string|max:255',
       ]);
 
       $data = $request->only([
@@ -65,7 +65,7 @@ class UserController extends Controller
       ]);
 
       $data['password'] = bcrypt($request->password);
-      $data['role'] = $request->role ?? 'user';
+      $data['role'] = $request->role;
 
       $user = User::create($data);
 
@@ -80,15 +80,15 @@ class UserController extends Controller
       $user = User::findOrFail($id);
 
       $request->validate([
-         'name' => 'sometimes|required|string|max:255',
-         'last_name' => 'sometimes|nullable|string|max:255',
-         'email' => 'sometimes|required|string|email|max:255|unique:users,email,' . $user->id,
-         'mobile_number' => 'sometimes|nullable|string|max:255',
-         'role' => 'sometimes|string|in:admin,user',
-         'country' => 'sometimes|nullable|string|max:255',
-         'address' => 'sometimes|nullable|string|max:255',
-         'city' => 'sometimes|nullable|string|max:255',
-         'postal_code' => 'sometimes|nullable|string|max:255',
+         'name' => 'required|string|max:255',
+         'last_name' => 'required|string|max:255',
+         'email' => 'required|string|email|max:255|unique:users,email,' . $user->id,
+         'mobile_number' => 'required|string|max:255',
+         'role' => 'required|string|in:admin,user',
+         'country' => 'required|string|max:255',
+         'address' => 'required|string|max:255',
+         'city' => 'required|string|max:255',
+         'postal_code' => 'required|string|max:255',
       ]);
 
       $user->update($request->only([

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -25,15 +25,16 @@ class AuthController extends Controller
 
         //validation
         $request->validate([
-            'name' => 'sometimes|string|max:100',
-            'last_name' => 'sometimes|string|max:100',
-            'email' => 'sometimes|string|email|max:255|unique:users,email',
-            'mobile_number' => ['sometimes', InternationalMobilePhone::forCreate()],//wenn wir required schreben wollen mussen wir 'name' schreiben,sonst gipt es ein Fehler HTTP 422 in yaak
-            'country' => 'sometimes|string|max:100',
-            'address' => 'sometimes|string|max:100',
-            'city' => 'sometimes|string|max:100',
-            'postal_code' => 'sometimes|string|max:10',
-            'password' => ['sometimes', 'string', $passwordRule] //sometimes-wenn gips dieses Feld dann validiere es,wenn nicht ist in ordnung
+            'name' => 'required|string|max:100',
+            'last_name' => 'required|string|max:100',
+            'email' => 'required|string|email|max:255|unique:users,email',
+            'mobile_number' => ['required', InternationalMobilePhone::forCreate()],
+            'country' => 'required|string|max:100',
+            'address' => 'required|string|max:100',
+            'city' => 'required|string|max:100',
+            'postal_code' => 'required|string|max:10',
+            'password' => ['required', 'string', $passwordRule],
+            'role' => 'required|string|in:admin,user'
         ]);
 
         $passwordHash = Hash::make($request->get('password')); //Wichtig, Hier wird sicher verschlüsselt geschpeichert das Passwort
@@ -49,7 +50,7 @@ class AuthController extends Controller
             'email' => $request->get('email'),
             'postal_code' => $request->get('postal_code'),
             'password' => $passwordHash,
-            'role' => $request->get('role', 'user') //wenn keine Rolle geschrieben wird,wird automatisch user gesetzt
+            'role' => $request->get('role')
         ]);
 
         // Send verification email to the newly registered user

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -24,7 +24,7 @@ class ProfileController extends Controller
             'address' => 'required|string|max:100',
             'city' => 'required|string|max:100',
             'postal_code' => 'required|string|max:10', // Changed from 'number' to 'string'
-            'mobile_number' => 'string|max:15',
+            'mobile_number' => 'required|string|max:15',
             'email' => "required|email|unique:users,email,{$user->id}",
             'password' => 'nullable|min:6|confirmed',
         ]);


### PR DESCRIPTION
## Summary
- enforce mandatory user attributes during registration
- require complete user data in admin user management
- ensure profile updates include mobile number

## Testing
- `php artisan test` *(fails: require(/workspace/MS-Lily_api/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893312241f8832e86414a6e090e1642